### PR TITLE
V2 versions for residual networks

### DIFF
--- a/deliravision/torch/models/backbones/__init__.py
+++ b/deliravision/torch/models/backbones/__init__.py
@@ -1,31 +1,27 @@
-from delira import  get_backends as __get_backends
-
 __all__ = []
 
-if "TORCH" in __get_backends():
+from .resnet import ResNetTorch
+from .vgg import VGGTorch
+from .alexnet import AlexNetTorch
+from .squeezenet import SqueezeNetTorch
+from .densenet import DenseNetTorch
+from .mobilenet import MobileNetV2Torch
+from .resnext import ResNeXtTorch
+from .seblocks import SEBasicBlockTorch, SEBottleneckTorch, \
+    SEBottleneckXTorch
+from .unet import UNetTorch, LinkNetTorch
 
-    from .resnet import ResNetTorch
-    from .vgg import VGGTorch
-    from .alexnet import AlexNetTorch
-    from .squeezenet import SqueezeNetTorch
-    from .densenet import DenseNetTorch
-    from .mobilenet import MobileNetV2Torch
-    from .resnext import ResNeXtTorch
-    from .seblocks import SEBasicBlockTorch, SEBottleneckTorch, \
-        SEBottleneckXTorch
-    from .unet import UNetTorch, LinkNetTorch
-
-    __all__ += [
-        "AlexNetTorch",
-        "DenseNetTorch",
-        "LinkNetTorch",
-        "MobileNetV2Torch",
-        "ResNetTorch",
-        "ResNeXtTorch",
-        "SEBasicBlockTorch",
-        "SEBottleneckTorch",
-        "SEBottleneckXTorch",
-        "SqueezeNetTorch",
-        "UNetTorch",
-        "VGGTorch",
-    ]
+__all__ += [
+    "AlexNetTorch",
+    "DenseNetTorch",
+    "LinkNetTorch",
+    "MobileNetV2Torch",
+    "ResNetTorch",
+    "ResNeXtTorch",
+    "SEBasicBlockTorch",
+    "SEBottleneckTorch",
+    "SEBottleneckXTorch",
+    "SqueezeNetTorch",
+    "UNetTorch",
+    "VGGTorch",
+]

--- a/deliravision/torch/models/basic_networks/__init__.py
+++ b/deliravision/torch/models/basic_networks/__init__.py
@@ -1,13 +1,9 @@
-from delira import get_backends as __get_backends
-
 __all__ = []
 
-if "TORCH" in __get_backends():
+from .segmentation import BaseSegmentationTorchNetwork
+from .classification import BaseClassificationTorchNetwork
 
-    from .segmentation import BaseSegmentationTorchNetwork
-    from .classification import BaseClassificationTorchNetwork
-
-    __all__ += [
-        "BaseSegmentationTorchNetwork",
-        "BaseClassificationTorchNetwork"
-    ]
+__all__ += [
+    "BaseSegmentationTorchNetwork",
+    "BaseClassificationTorchNetwork"
+]

--- a/deliravision/torch/models/decoders/__init__.py
+++ b/deliravision/torch/models/decoders/__init__.py
@@ -1,6 +1,4 @@
-from delira import get_backends as __get_backends
+from .extractor import ExtractorTorch, extract_layers_by_str
+from .fpn import FPNTorch
+from .unet import UNetTorch
 
-if "TORCH" in __get_backends():
-    from .extractor import ExtractorTorch, extract_layers_by_str
-    from .fpn import FPNTorch
-    from .unet import UNetTorch

--- a/deliravision/torch/models/model_fns.py
+++ b/deliravision/torch/models/model_fns.py
@@ -66,7 +66,9 @@ DENSENET_CONFIGS = {
 
 def create_resnet_torch(num_layers: int, num_classes=1000, in_channels=3,
                         start_filts=64, zero_init_residual=False,
-                        norm_layer="Batch", n_dim=2, **kwargs):
+                        norm_layer="Batch", n_dim=2,
+                        deep_start=False, avg_down=False,
+                        **kwargs):
     config = RESNET_CONFIGS[str(num_layers)]
 
     return ResNet(config["block"], config["layers"],
@@ -74,12 +76,16 @@ def create_resnet_torch(num_layers: int, num_classes=1000, in_channels=3,
                   in_channels=in_channels,
                   zero_init_residual=zero_init_residual,
                   start_filts=start_filts,
-                  norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+                  norm_layer=norm_layer, n_dim=n_dim,
+                  deep_start=False, avg_down=False,
+                  **kwargs)
 
-
+                  
 def create_seresnet_torch(num_layers: int, num_classes=1000, in_channels=3,
                           start_filts=64, zero_init_residual=False,
-                          norm_layer="Batch", n_dim=2, **kwargs):
+                          norm_layer="Batch", n_dim=2,
+                          deep_start=False, avg_down=False,
+                          **kwargs):
     config = SERESNET_CONFIGS[str(num_layers)]
 
     return ResNet(config["block"], config["layers"],
@@ -87,31 +93,41 @@ def create_seresnet_torch(num_layers: int, num_classes=1000, in_channels=3,
                   in_channels=in_channels,
                   zero_init_residual=zero_init_residual,
                   start_filts=start_filts,
-                  norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+                  norm_layer=norm_layer, n_dim=n_dim,
+                  deep_start=False, avg_down=False,
+                  **kwargs)
 
 
 def create_resnext_torch(num_layers: int, num_classes=1000, in_channels=3,
                          cardinality=32, width=4, start_filts=64,
-                         norm_layer="Batch", n_dim=2, **kwargs):
+                         norm_layer="Batch", n_dim=2,
+                         deep_start=False, avg_down=False,
+                         **kwargs):
     config = RESNEXT_CONFIGS[str(num_layers)]
 
     return ResNeXtTorch(config["block"], config["layers"],
                         num_classes=num_classes,
                         in_channels=in_channels, cardinality=cardinality,
                         width=width, start_filts=start_filts,
-                        norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+                        norm_layer=norm_layer, n_dim=n_dim,
+                        deep_start=False, avg_down=False,
+                        **kwargs)
 
 
 def create_seresnext_torch(num_layers: int, num_classes=1000, in_channels=3,
                            cardinality=32, width=4, start_filts=64,
-                           norm_layer="Batch", n_dim=2, **kwargs):
+                           norm_layer="Batch", n_dim=2,
+                           deep_start=False, avg_down=False,
+                           **kwargs):
     config = SERESNEXT_CONFIGS[str(num_layers)]
 
     return ResNeXtTorch(config["block"], config["layers"],
                         num_classes=num_classes,
                         in_channels=in_channels, cardinality=cardinality,
                         width=width, start_filts=start_filts,
-                        norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+                        norm_layer=norm_layer, n_dim=n_dim,
+                        deep_start=False, avg_down=False,
+                        **kwargs)
 
 
 def create_vgg_torch(num_layers: int, num_classes=1000, in_channels=3,

--- a/deliravision/torch/models/model_fns.py
+++ b/deliravision/torch/models/model_fns.py
@@ -45,11 +45,11 @@ SERESNEXT_CONFIGS = {
 VGG_CONFIGS = {
     '11': [64, 'P', 128, 'P', 256, 256, 'P', 512, 512, 'P', 512, 512, 'P'],
     '13': [64, 64, 'P', 128, 128, 'P', 256, 256, 'P', 512, 512, 'P', 512,
-            512, 'P'],
+           512, 'P'],
     '16': [64, 64, 'P', 128, 128, 'P', 256, 256, 256, 'P', 512, 512, 512,
-            'P', 512, 512, 512, 'P'],
+           'P', 512, 512, 512, 'P'],
     '19': [64, 64, 'P', 128, 128, 'P', 256, 256, 256, 256, 'P', 512, 512,
-            512, 512, 'P', 512, 512, 512, 512, 'P'],
+           512, 512, 'P', 512, 512, 512, 512, 'P'],
 }
 
 DENSENET_CONFIGS = {
@@ -63,71 +63,73 @@ DENSENET_CONFIGS = {
             "block_config": (6, 12, 48, 32)},
 }
 
+
 def create_resnet_torch(num_layers: int, num_classes=1000, in_channels=3,
                         start_filts=64, zero_init_residual=False,
-                        norm_layer="Batch", n_dim=2):
+                        norm_layer="Batch", n_dim=2, **kwargs):
     config = RESNET_CONFIGS[str(num_layers)]
 
     return ResNet(config["block"], config["layers"],
-                    num_classes=num_classes,
-                    in_channels=in_channels,
-                    zero_init_residual=zero_init_residual,
-                    start_filts=start_filts,
-                    norm_layer=norm_layer, n_dim=n_dim)
+                  num_classes=num_classes,
+                  in_channels=in_channels,
+                  zero_init_residual=zero_init_residual,
+                  start_filts=start_filts,
+                  norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+
 
 def create_seresnet_torch(num_layers: int, num_classes=1000, in_channels=3,
-                            start_filts=64, zero_init_residual=False,
-                            norm_layer="Batch", n_dim=2):
+                          start_filts=64, zero_init_residual=False,
+                          norm_layer="Batch", n_dim=2, **kwargs):
     config = SERESNET_CONFIGS[str(num_layers)]
 
     return ResNet(config["block"], config["layers"],
-                    num_classes=num_classes,
-                    in_channels=in_channels,
-                    zero_init_residual=zero_init_residual,
-                    start_filts=start_filts,
-                    norm_layer=norm_layer, n_dim=n_dim)
+                  num_classes=num_classes,
+                  in_channels=in_channels,
+                  zero_init_residual=zero_init_residual,
+                  start_filts=start_filts,
+                  norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+
 
 def create_resnext_torch(num_layers: int, num_classes=1000, in_channels=3,
-                            cardinality=32, width=4, start_filts=64,
-                            norm_layer="Batch",
-                            n_dim=2, start_mode="7x7"):
+                         cardinality=32, width=4, start_filts=64,
+                         norm_layer="Batch", n_dim=2, **kwargs):
     config = RESNEXT_CONFIGS[str(num_layers)]
 
     return ResNeXtTorch(config["block"], config["layers"],
-                            num_classes=num_classes,
-                            in_channels=in_channels, cardinality=cardinality,
-                            width=width, start_filts=start_filts,
-                            norm_layer=norm_layer, n_dim=n_dim,
-                            start_mode=start_mode)
+                        num_classes=num_classes,
+                        in_channels=in_channels, cardinality=cardinality,
+                        width=width, start_filts=start_filts,
+                        norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+
 
 def create_seresnext_torch(num_layers: int, num_classes=1000, in_channels=3,
-                            cardinality=32, width=4, start_filts=64,
-                            norm_layer="Batch",
-                            n_dim=2):
+                           cardinality=32, width=4, start_filts=64,
+                           norm_layer="Batch", n_dim=2, **kwargs):
     config = SERESNEXT_CONFIGS[str(num_layers)]
 
     return ResNeXtTorch(config["block"], config["layers"],
-                            num_classes=num_classes,
-                            in_channels=in_channels, cardinality=cardinality,
-                            width=width, start_filts=start_filts,
-                            norm_layer=norm_layer, n_dim=n_dim)
+                        num_classes=num_classes,
+                        in_channels=in_channels, cardinality=cardinality,
+                        width=width, start_filts=start_filts,
+                        norm_layer=norm_layer, n_dim=n_dim, **kwargs)
+
 
 def create_vgg_torch(num_layers: int, num_classes=1000, in_channels=3,
-                        init_weights=True, n_dim=2, norm_type="Batch",
-                        pool_type="Max"):
+                     init_weights=True, n_dim=2, norm_type="Batch",
+                     pool_type="Max", **kwargs):
 
     config = VGG_CONFIGS[str(num_layers)]
 
     return VGG(config, num_classes=num_classes,
-                in_channels=in_channels, init_weights=init_weights,
-                n_dim=n_dim, norm_type=norm_type, pool_type=pool_type)
+               in_channels=in_channels, init_weights=init_weights,
+               n_dim=n_dim, norm_type=norm_type, pool_type=pool_type, **kwargs)
+
 
 def create_densenet_torch(num_layers: int, bn_size=4, drop_rate=0,
-                            num_classes=1000, n_dim=2, pool_type="Max",
-                            norm_type="Batch"):
+                          num_classes=1000, n_dim=2, pool_type="Max",
+                          norm_type="Batch", **kwargs):
     config = DENSENET_CONFIGS[str(num_layers)]
 
     return DenseNetTorch(**config, bn_size=bn_size, drop_rate=drop_rate,
-                            num_classes=num_classes, n_dim=n_dim,
-                            pool_type=pool_type, norm_type=norm_type)
-
+                         num_classes=num_classes, n_dim=n_dim,
+                         pool_type=pool_type, norm_type=norm_type, **kwargs)

--- a/deliravision/torch/models/utils/__init__.py
+++ b/deliravision/torch/models/utils/__init__.py
@@ -1,5 +1,2 @@
-from delira import get_backends
-
-if "TORCH" in get_backends():
-    from .nd_wrapper_torch import ConvWrapper as ConvNdTorch, \
-        NormWrapper as NormNdTorch, PoolingWrapper as PoolingNdTorch, DropoutWrapper as DropoutNdTorch
+from .nd_wrapper_torch import ConvWrapper as ConvNdTorch, \
+    NormWrapper as NormNdTorch, PoolingWrapper as PoolingNdTorch, DropoutWrapper as DropoutNdTorch

--- a/tests/models/test_backbones_torch.py
+++ b/tests/models/test_backbones_torch.py
@@ -16,7 +16,8 @@ class TestBackbones(unittest.TestCase):
             "network_cls": SqueezeNetTorch,
             "network_kwargs": {'version': 1.0, "num_classes": 1000,
                                "in_channels": 3, "n_dim": 2,
-                               "pool_type": "Max", "p_dropout": 0.5},
+                               "pool_type": "Max", "p_dropout": 0.5,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SqueezeNet1.0"
         })
@@ -24,148 +25,194 @@ class TestBackbones(unittest.TestCase):
             "network_cls": SqueezeNetTorch,
             "network_kwargs": {'version': 1.1, "num_classes": 1000,
                                "in_channels": 3, "n_dim": 2,
-                               "pool_type": "Max", "p_dropout": 0.5},
+                               "pool_type": "Max", "p_dropout": 0.5,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SqueezeNet1.1"
         })
         test_cases.append({
             "network_cls": AlexNetTorch,
             "network_kwargs": {"num_classes": 1000, "in_channels": 3,
-                               "n_dim": 2, "pool_type": "Max"},
+                               "n_dim": 2, "pool_type": "Max",
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "AlexNet"
         })
         test_cases.append({
             "network_cls": create_vgg_torch,
-            "network_kwargs": {"num_layers": 11},
+            "network_kwargs": {"num_layers": 11,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "VGG11"
         })
         test_cases.append({
             "network_cls": create_vgg_torch,
-            "network_kwargs": {"num_layers": 13},
+            "network_kwargs": {"num_layers": 13,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "VGG13"
         })
         test_cases.append({
             "network_cls": create_vgg_torch,
-            "network_kwargs": {"num_layers": 16},
+            "network_kwargs": {"num_layers": 16,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "VGG16"
         })
         test_cases.append({
             "network_cls": create_vgg_torch,
-            "network_kwargs": {"num_layers": 19},
+            "network_kwargs": {"num_layers": 19,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "VGG19"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 18,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet18"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 34,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet34"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 26,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet26"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 50,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet50"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
+            "network_kwargs": {"num_layers": 50,
+                               "zero_init_residual": True,
+                               "deep_start": True,
+                               "avg_down": True,
+                               },
+            "input_shape": (5, 3, 224, 224),
+            "name": "ResNet50V2"
+        })
+        test_cases.append({
+            "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 101,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet101"
         })
         test_cases.append({
             "network_cls": create_resnet_torch,
             "network_kwargs": {"num_layers": 152,
-                               "zero_init_residual": True},
+                               "zero_init_residual": True,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNet152"
         })
         test_cases.append({
             "network_cls": create_densenet_torch,
             "network_kwargs": {"num_layers": 121,
-                               "drop_rate": 0.2},
+                               "drop_rate": 0.2,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "DenseNet121"
         })
         test_cases.append({
             "network_cls": create_densenet_torch,
             "network_kwargs": {"num_layers": 161,
-                               "drop_rate": 0.2},
+                               "drop_rate": 0.2,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "DenseNet161"
         })
         test_cases.append({
             "network_cls": create_densenet_torch,
             "network_kwargs": {"num_layers": 169,
-                               "drop_rate": 0.2},
+                               "drop_rate": 0.2,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "DenseNet169"
         })
         test_cases.append({
             "network_cls": create_densenet_torch,
             "network_kwargs": {"num_layers": 201,
-                               "drop_rate": 0.2},
+                               "drop_rate": 0.2,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "DenseNet201"
         })
         test_cases.append({
             "network_cls": create_resnext_torch,
             "network_kwargs": {"num_layers": 26,
-                               "start_mode": "7x7"},
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNeXt26"
         })
         test_cases.append({
             "network_cls": create_resnext_torch,
+            "network_kwargs": {"num_layers": 26,
+                               "deep_start": True,
+                               "avg_down": True,
+                               },
+            "input_shape": (5, 3, 224, 224),
+            "name": "ResNeXt26V2"
+        })
+        test_cases.append({
+            "network_cls": create_resnext_torch,
             "network_kwargs": {"num_layers": 50,
-                               "start_mode": "3x3"},
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNeXt50"
         })
         test_cases.append({
             "network_cls": create_resnext_torch,
             "network_kwargs": {"num_layers": 101,
-                               "start_mode": "7x7"},
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNeXt101"
         })
         test_cases.append({
             "network_cls": create_resnext_torch,
             "network_kwargs": {"num_layers": 152,
-                               "start_mode": "3x3"},
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "ResNeXt152"
         })
         test_cases.append({
             "network_cls": create_seresnet_torch,
-            "network_kwargs": {"num_layers": 18},
+            "network_kwargs": {"num_layers": 18,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNet18"
         })
         test_cases.append({
             "network_cls": create_seresnet_torch,
-            "network_kwargs": {"num_layers": 34},
+            "network_kwargs": {"num_layers": 18,
+                               "deep_start": True,
+                               "avg_down": True
+                               },
+            "input_shape": (5, 3, 224, 224),
+            "name": "SEResNet18V2"
+        })
+        test_cases.append({
+            "network_cls": create_seresnet_torch,
+            "network_kwargs": {"num_layers": 34,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNet34"
         })
@@ -177,19 +224,22 @@ class TestBackbones(unittest.TestCase):
         })
         test_cases.append({
             "network_cls": create_seresnet_torch,
-            "network_kwargs": {"num_layers": 50},
+            "network_kwargs": {"num_layers": 50,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNet50"
         })
         test_cases.append({
             "network_cls": create_seresnet_torch,
-            "network_kwargs": {"num_layers": 101},
+            "network_kwargs": {"num_layers": 101,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNet101"
         })
         test_cases.append({
             "network_cls": create_seresnet_torch,
-            "network_kwargs": {"num_layers": 152},
+            "network_kwargs": {"num_layers": 152,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNet152"
         })
@@ -197,25 +247,38 @@ class TestBackbones(unittest.TestCase):
         test_cases.append({
             "network_cls": create_seresnext_torch,
             "network_kwargs": {"num_layers": 26,
-                               "cardinality": 1},
+                               "cardinality": 1,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNeXt26"
         })
         test_cases.append({
             "network_cls": create_seresnext_torch,
-            "network_kwargs": {"num_layers": 50},
+            "network_kwargs": {"num_layers": 26,
+                               "deep_start": True,
+                               "avg_down": True,
+                               },
+            "input_shape": (5, 3, 224, 224),
+            "name": "SEResNeXt26V2"
+        })
+        test_cases.append({
+            "network_cls": create_seresnext_torch,
+            "network_kwargs": {"num_layers": 50,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNeXt50"
         })
         test_cases.append({
             "network_cls": create_seresnext_torch,
-            "network_kwargs": {"num_layers": 101},
+            "network_kwargs": {"num_layers": 101,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNeXt101"
         })
         test_cases.append({
             "network_cls": create_seresnext_torch,
-            "network_kwargs": {"num_layers": 152},
+            "network_kwargs": {"num_layers": 152,
+                               },
             "input_shape": (5, 3, 224, 224),
             "name": "SEResNeXt152"
         })


### PR DESCRIPTION
- [x]  ResNetV2
- [x] ResNeXtV2
- [x] SEResNetV2
- [x] SEResNeXtV2

Do we introduce additional "constructors" in `model_fns` or do we leave it like where the arguments can be passed via kwargs?

Closes https://github.com/delira-dev/vision_torch/issues/5